### PR TITLE
Applet does not repeat Command::Connect if it launches service after connecting failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ Example: `"/home/user/.bin/notes-service"`
 
 Default value: `"/usr/local/bin/notes-service"`
 
+### connect_service_pause_ms
+optional
+
+When *notes-applet* starts it connects the *notes-service*. If connecting fails the applet launches the service (defined in *service_bin*), then it waits some time and retries to connect after that again. This parameter defines in milliseconds how long the applet will wait before retrying to connect the service.
+
+Value type: `integer`
+
+Example: `2_000`
+
+Default value: `1_000`
+
 ### import_file
 optional
 
@@ -139,7 +150,7 @@ optional
 
 Overrides the size of icons in the sticky window toolbar.
 
-Value type: integer
+Value type: `integer`
 
 Example: `32`
 
@@ -153,7 +164,6 @@ Contains sticky-notes database.
 Value type: `JSON string` (i.e. in double quotes).
 
 :exclamation: Edit carefully otherwise it won't be read properly. It is highly recommended to edit notes in sticky windows and settings
-
 
 ## Build, install and run
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,7 @@ pub struct Config {
     pub toolbar_icon_size: u16,
     pub note_min_width: usize,
     pub note_min_height: usize,
+    pub connect_service_pause_ms: u64,
 }
 
 impl Default for Config {
@@ -48,6 +49,7 @@ impl Default for Config {
             note_min_width: 64,
             note_min_height: 64,
             toolbar_icon_size: ICON_SIZE,
+            connect_service_pause_ms: 1_000,
         }
     }
 }


### PR DESCRIPTION
Fixes #22

When *notes-applet* starts it connects the *notes-service*. If connecting fails the applet launches the service (defined in *service_bin*), then it waits some time and retries to connect after that again. This parameter defines in milliseconds how long the applet will wait before retrying to connect the service.