### PR TITLE
Save notes in background regularly Fixes #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ Example: `2_000`
 
 Default value: `1_000`
 
+### autosave_period_ms
+optional
+
+If this parameter is non zero it defines the period of time in milliseconds to autosave all changes in notes. If it is set to 0 autosave feature is off.
+
+Value type: `integer`
+
+Example: `0`
+
+Default value: `30_000`
+
 ### import_file
 optional
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,8 @@ pub struct Config {
     pub note_min_width: usize,
     pub note_min_height: usize,
     pub connect_service_pause_ms: u64,
+    // Test and save period. If 0 autosave is off:
+    pub autosave_period_ms: u64,
 }
 
 impl Default for Config {
@@ -50,6 +52,7 @@ impl Default for Config {
             note_min_height: 64,
             toolbar_icon_size: ICON_SIZE,
             connect_service_pause_ms: 1_000,
+            autosave_period_ms: 30_000,
         }
     }
 }


### PR DESCRIPTION
Add `auto save_period_ms` parameter to configuration.
If this parameter is non zero it defines the period of time in milliseconds to auto save all changes in notes. If it is set to 0 auto save feature is off.

Fixes #23